### PR TITLE
Update crear_pago response format

### DIFF
--- a/packages/vertice/src/route/pagos.py
+++ b/packages/vertice/src/route/pagos.py
@@ -107,7 +107,7 @@ async def crear_pago():
             }
             await add_billete(billete_data)
 
-        return jsonify({"ok": True, "pago_id": pago_id})
+        return jsonify({"type": "success", "data": {"pago_id": pago_id}})
 
     except Exception as e:
         traceback.print_exc()


### PR DESCRIPTION
## Summary
- modify the pagos endpoint to return a `type: "success"` payload containing the new payment id

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685c820971a08324abc7dd91448d7aad