### PR TITLE
Fix user modal closing on submit

### DIFF
--- a/packages/front/src/routes/(sistemas)/administrador/usuarios/+page.svelte
+++ b/packages/front/src/routes/(sistemas)/administrador/usuarios/+page.svelte
@@ -77,7 +77,10 @@
     }
 
     const handleSubmit: SubmitFunction = ({formElement}) => {
-        return resolver(() => formElement.reset());
+        return resolver(() => {
+            formElement.reset();
+            modalVisible = false;
+        });
     };
 
     const downloadSubmit: SubmitFunction = () => {


### PR DESCRIPTION
## Summary
- close the user modal after submitting the form

## Testing
- `npm run lint` (fails to run due to missing configuration)
- `npm run check` (fails: `svelte-kit` not found)


------
https://chatgpt.com/codex/tasks/task_e_685c59f2c4f88324967c9c0ee7184a49