### PR TITLE
Remove docente especialidad

### DIFF
--- a/packages/front/src/app.d.ts
+++ b/packages/front/src/app.d.ts
@@ -37,12 +37,11 @@ export type Docente = {
 	nombre: string;
 	correo: string;
 	usuario: number;
-	titulo: string;
-	dedicacion: string;
-	especialidad: string;
-	estatus: string;
-	fecha_ingreso: string;
-	observaciones: string;
+        titulo: string;
+        dedicacion: string;
+        estatus: string;
+        fecha_ingreso: string;
+        observaciones: string;
 };
 
 export type Estudiante = {

--- a/packages/front/src/lib/types.ts
+++ b/packages/front/src/lib/types.ts
@@ -11,10 +11,9 @@ export type EstudianteReq = {
 };
 
 export type DocenteReq = {
-	usuario_id: number;
-	titulo: string;
-	especialidad: string;
-	fecha_ingreso: string;
+        usuario_id: number;
+        titulo: string;
+        fecha_ingreso: string;
 };
 
 export type CoordinadorReq = {

--- a/packages/front/src/routes/(sistemas)/docentes/+page.server.ts
+++ b/packages/front/src/routes/(sistemas)/docentes/+page.server.ts
@@ -13,14 +13,13 @@ import type { Actions, PageServerLoad } from './$types';
 import { format } from 'date-fns';
 
 export type ErroresDocente = {
-	cedula?: string;
-	nombre?: string;
-	correo?: string;
-	password?: string;
-	titulo?: string;
-	especialidad?: string;
-	fecha_ingreso?: string;
-	activo?: string;
+        cedula?: string;
+        nombre?: string;
+        correo?: string;
+        password?: string;
+        titulo?: string;
+        fecha_ingreso?: string;
+        activo?: string;
 };
 
 
@@ -72,12 +71,11 @@ export const actions: Actions = {
 			return { success: false, message: error instanceof Error ? error.message : 'Error desconocido' };
 		}
 
-		const docente: DocenteReq = {
-			titulo: payload.titulo,
-			especialidad: payload.especialidad,
-			fecha_ingreso: format(new Date(payload.fecha_ingreso), 'dd/MM/yyyy'),
-			usuario_id: usuario.id,
-		};
+                const docente: DocenteReq = {
+                        titulo: payload.titulo,
+                        fecha_ingreso: format(new Date(payload.fecha_ingreso), 'dd/MM/yyyy'),
+                        usuario_id: usuario.id
+                };
 
 		try {
 			await crearDocente(fetch, docente);
@@ -124,12 +122,11 @@ export const actions: Actions = {
 			return { success: false, message: error instanceof Error ? error.message : 'Error desconocido' };
 		}
 
-		const docente: DocenteReq = {
-			titulo: payload.titulo,
-			especialidad: payload.especialidad,
-			fecha_ingreso: format(new Date(payload.fecha_ingreso), 'dd/MM/yyyy'),
-			usuario_id: payload.id,
-		};
+                const docente: DocenteReq = {
+                        titulo: payload.titulo,
+                        fecha_ingreso: format(new Date(payload.fecha_ingreso), 'dd/MM/yyyy'),
+                        usuario_id: payload.id
+                };
 
 		try {
 			await actualizarDocente(fetch, payload.id_docente, docente);
@@ -172,14 +169,13 @@ function validarPayload(
 	const errores: ErroresDocente = {};
 
 	// Campos requeridos comunes
-	const camposBase: (keyof ErroresDocente)[] = [
-		'cedula',
-		'nombre',
-		'correo',
-		'titulo',
-		'especialidad',
-		'fecha_ingreso',
-	];
+        const camposBase: (keyof ErroresDocente)[] = [
+                'cedula',
+                'nombre',
+                'correo',
+                'titulo',
+                'fecha_ingreso'
+        ];
 
 	for (const campo of camposBase) {
 		const valor = payload[campo];

--- a/packages/front/src/routes/(sistemas)/docentes/+page.svelte
+++ b/packages/front/src/routes/(sistemas)/docentes/+page.svelte
@@ -23,7 +23,6 @@
         correo: string;
         fecha_ingreso: Date | string;
         titulo: string;
-        especialidad: string;
         usuario: number;
     }> = $state({
         cedula: '',
@@ -51,7 +50,6 @@
                 data?.docentes.filter(
                     (est) =>
                         est?.dedicacion?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                        est?.especialidad?.toLowerCase().includes(searchTerm.toLowerCase()) ||
                         est?.titulo?.toLowerCase().includes(searchTerm.toLowerCase()) ||
                         est.fecha_ingreso.toLowerCase().includes(searchTerm.toLowerCase())
                 ) ?? [];
@@ -64,7 +62,6 @@
         docentes.filter(
             (est) =>
                 est?.dedicacion?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                est?.especialidad?.toLowerCase().includes(searchTerm.toLowerCase()) ||
                 est?.titulo?.toLowerCase().includes(searchTerm.toLowerCase()) ||
                 est.fecha_ingreso.toLowerCase().includes(searchTerm.toLowerCase())
         ) ?? []
@@ -167,16 +164,6 @@
                             name="titulo"
                             placeholder="Ingrese el titulo"
                             value={docenteActual!.titulo}
-                            required
-                    />
-                </div>
-                <div class="md:col-span-2">
-                    <Label for="especialidad" class="mb-2">Especialidad</Label>
-                    <Input
-                            id="especialidad"
-                            name="especialidad"
-                            placeholder="Ingrese la especialidad"
-                            value={docenteActual!.nombre}
                             required
                     />
                 </div>

--- a/packages/vertice/migrations/models/6_20250625202115_update.py
+++ b/packages/vertice/migrations/models/6_20250625202115_update.py
@@ -1,0 +1,13 @@
+from tortoise import BaseDBAsyncClient
+
+
+async def upgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        ALTER TABLE "docentes" DROP COLUMN "especialidad";
+    """
+
+
+async def downgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        ALTER TABLE "docentes" ADD "especialidad" VARCHAR(100);
+    """

--- a/packages/vertice/src/model/docente.py
+++ b/packages/vertice/src/model/docente.py
@@ -4,7 +4,6 @@ from tortoise import fields
 class Docente(Model):
     usuario = fields.OneToOneField('models.Usuario', related_name='docente')
     titulo = fields.CharField(max_length=50, null=True)
-    especialidad = fields.CharField(max_length=100, null=True)
     fecha_ingreso = fields.DateField(null=True)
 
     class Meta:

--- a/packages/vertice/src/route/archivos.py
+++ b/packages/vertice/src/route/archivos.py
@@ -407,7 +407,6 @@ async def importar_usuarios():
                     datos = {
                         "usuario_id": usuario.id,
                         "titulo": row["Titulo"] if "Titulo" in row and pd.notna(row["Titulo"]) else "",
-                        "especialidad": row["Especialidad"] if "Especialidad" in row and pd.notna(row["Especialidad"]) else "",
                         "fecha_ingreso": row["Fecha ingreso"] if "Fecha ingreso" in row and pd.notna(row["Fecha ingreso"]) else None,
                     }
                 elif rol == "coordinador":

--- a/packages/vertice/src/service/docentes.py
+++ b/packages/vertice/src/service/docentes.py
@@ -17,7 +17,6 @@ async def get_docentes():
                 "correo": d.usuario.correo,
                 "usuario": d.usuario.id,
                 "titulo": d.titulo,
-                "especialidad": d.especialidad,
                 "fecha_ingreso": format_fecha(d.fecha_ingreso) if d.fecha_ingreso else None,
             })
         return resultado
@@ -34,7 +33,6 @@ async def get_docente(id: int):
             "nombre": d.usuario.nombre,
             "correo": d.usuario.correo,
             "titulo": d.titulo,
-            "especialidad": d.especialidad,
             "fecha_ingreso": format_fecha(d.fecha_ingreso) if d.fecha_ingreso else None,
         }
     except DoesNotExist:
@@ -42,13 +40,12 @@ async def get_docente(id: int):
     except Exception as ex:
         raise Exception(ex)
 
-async def add_docente(usuario_id: int, titulo: str, especialidad: str, fecha_ingreso=None):
+async def add_docente(usuario_id: int, titulo: str, fecha_ingreso=None):
     try:
         usuario = await Usuario.get(id=usuario_id)
         docente = Docente(
             usuario=usuario,
             titulo=titulo,
-            especialidad=especialidad,
             fecha_ingreso=parse_fecha(fecha_ingreso) if fecha_ingreso else None,
         )
         await docente.save()

--- a/packages/vertice/src/service/materias.py
+++ b/packages/vertice/src/service/materias.py
@@ -333,8 +333,7 @@ async def listar_materias_asignadas():
                 "docente": {
                     "cedula": usuario.cedula,
                     "nombre": usuario.nombre,
-                    "titulo": docente.titulo,
-                    "especialidad": docente.especialidad
+                    "titulo": docente.titulo
                 }
             })
 


### PR DESCRIPTION
## Summary
- drop `especialidad` field from Docente model
- adjust services and routes for new model
- update migrations for dropping column
- clean docente UI and validation on the frontend
- update Docente types without `especialidad`

## Testing
- `pnpm -r lint` *(fails: prettier and eslint not installed)*
- `poetry run aerich upgrade` *(fails: aerich command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c59a80ecc8324863d0821403d03e9