### PR TITLE
Fix role check for estudiantes page

### DIFF
--- a/packages/front/src/routes/(sistemas)/estudiantes/+page.svelte
+++ b/packages/front/src/routes/(sistemas)/estudiantes/+page.svelte
@@ -132,7 +132,7 @@
 <div class="w-full">
 	<div class="flex justify-between items-center mb-6">
 		<h1 class="text-2xl font-bold">Estudiantes</h1>
-		{#if data.rol !== 'coordinador'}
+               {#if data.rol !== 'coordinador' && data.rol !== 'caja'}
 			<Button color="blue" onclick={crearEstudiante}>
 				<PlusOutline class="mr-2 h-5 w-5" />
 				Registrar
@@ -146,7 +146,7 @@
 
 	{#snippet actions(row: Estudiante)}
 		<div class="flex gap-2">
-			{#if data.rol !== 'coordinador'}
+                       {#if data.rol !== 'coordinador' && data.rol !== 'caja'}
 				<Button pill size="xs" class="p-1.5!" color="light" onclick={() => editarEstudiante(row)}>
 					<PenOutline class="w-5 h-5" />
 				</Button>


### PR DESCRIPTION
## Summary
- restrict estudiante management for "caja" role

## Testing
- `pnpm --filter ./packages/front lint` *(fails: Command "prettier && eslint" exit status 1; node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c59f876c08324b7a5b73546c1ad72