### PR TITLE
Extend session duration

### DIFF
--- a/packages/front/src/routes/+page.server.ts
+++ b/packages/front/src/routes/+page.server.ts
@@ -18,13 +18,13 @@ export const actions = {
 		try {
 			const { usuario, token } = await login(fetch, correo, password);
 
-			cookies.set('sesion', token, {
-				path: '/',
-				httpOnly: true,
-				sameSite: 'strict',
-				secure: false, // true en producción
-				maxAge: 60 * 60 * 2 // 2h
-			});
+                        cookies.set('sesion', token, {
+                                path: '/',
+                                httpOnly: true,
+                                sameSite: 'strict',
+                                secure: false, // true en producción
+                                maxAge: 60 * 60 * 8 // 8h
+                        });
 
 			destino = `/${usuario.rol.nombre.toLowerCase()}`;
 			return {

--- a/packages/vertice/src/route/usuario.py
+++ b/packages/vertice/src/route/usuario.py
@@ -35,7 +35,7 @@ async def login_usuario():
 
         access_token = create_access_token(
             identity=usuario.correo,
-            expires_delta=timedelta(hours=2),
+            expires_delta=timedelta(hours=8),
             additional_claims=claims
         )
 


### PR DESCRIPTION
## Summary
- keep session valid for 8 hours in the backend
- increase cookie `maxAge` to 8 hours on the login page

## Testing
- `pnpm lint` *(fails: node modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c820afb3483248ca4c5aac2e98563